### PR TITLE
Filter initialization changes

### DIFF
--- a/insitu/inc/filter_factory.hpp
+++ b/insitu/inc/filter_factory.hpp
@@ -35,7 +35,8 @@ public:
     std::vector<std::string> getFilterList(void);
 
     boost::shared_ptr<insitu::Filter> loadFilter(const std::string& filter,
-                                                 const std::string& name);
+                                                 const std::string& name,
+                                                 const std::string& topic);
 
     bool unloadFilter(const std::string& name);
 

--- a/insitu/inc/filter_graphics_item.hpp
+++ b/insitu/inc/filter_graphics_item.hpp
@@ -48,26 +48,16 @@ public:
 
     void updateFilter(const cv::Mat& filter);
 
-    void setResizable(bool resizeable);
-
     boost::shared_ptr<insitu::Filter> getFilter(void) const;
 
 protected:
-    void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
-
-    void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
-
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
-
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                QWidget* widget = nullptr) override;
 
 public slots:
-
     void queuedUpdate(void);
 
 signals:
-
     void delayedUpdate(void);
 
     void imgSizeChanged(QSize size);
@@ -85,12 +75,6 @@ private:
 
     mutable QMutex img_mutex;
 
-    bool isResizable;
-
-    bool isResizing;
-
-    double initDist;
-    double initScale;
 };
 
 }    // namespace insitu

--- a/insitu/inc/filtered_view.hpp
+++ b/insitu/inc/filtered_view.hpp
@@ -110,6 +110,8 @@ public:
 
     ~FilteredView(void);
 
+    std::string getViewTopic(void) const;
+
     void addFilter(boost::shared_ptr<insitu::Filter> filter);
 
     const std::string& getViewName(void) const;

--- a/insitu/lib/insitu/filter.hpp
+++ b/insitu/lib/insitu/filter.hpp
@@ -117,10 +117,6 @@ protected:
     }
 
 public:
-    void init (const std::string& name, const nodelet::M_string& argm, const nodelet::V_string& argv)
-    {
-        filterWatchdog.setImageTopic(argv[0]);
-    }
 
     /*
         @Filter implementors: reimplement this function to apply filter effects
@@ -255,19 +251,22 @@ public:
         return filterWatchdog.getGraphicsItem();
     }
 
+    void onInit(void)
+    {
+        nodelet::V_string argv = getMyArgv();
+        filterWatchdog.setImageTopic(argv[0]);
+        size = QSize(0,0);
+
+        filterInit();
+    }
+
 protected:
     /*
-        @Filter implementors: reimplement this function with any initialization
+        @Filter implementors:  must override this function with any initialization
         required; the creating of data structures, global variables, etc. All
         initialization of the ROS infrastructure must be put into this function.
     */
-    virtual void onInit(void)
-    {
-        settingsDialog = new FilterDialog(this);
-        settingsDialog->setWindowTitle(QString::fromStdString(name()) +
-                                       " Settings");
-        size = QSize(300,300);
-    };
+    virtual void filterInit(void) = 0;
 
     /*
         @Filter implementors: reimplement this function to include any cleanup

--- a/insitu/lib/insitu/filter.hpp
+++ b/insitu/lib/insitu/filter.hpp
@@ -13,6 +13,7 @@
 #include <opencv2/core/core.hpp>
 
 // C++ includes
+#include <string>
 #include <thread>
 #include <future>
 #include <chrono>
@@ -44,16 +45,26 @@ class FilterWatchdog : public QObject
     Q_OBJECT
 private:
     QGraphicsItem* graphicsItem;
+    
+    std::string baseImageTopic;
 
 public:
     FilterWatchdog(QGraphicsItem* item)
-    {
-        graphicsItem = item;
-    }
+        : graphicsItem(item) {}
 
     void notify(const cv::Mat& update)
     {
         emit filterUpdated(graphicsItem, update);
+    }
+
+    void setImageTopic(const std::string& topic)
+    {
+        baseImageTopic = topic;
+    }
+
+    const std::string& imageTopic(void) const
+    {
+        return baseImageTopic;
     }
 
     QGraphicsItem* getGraphicsItem(void) const
@@ -64,6 +75,13 @@ public:
 signals:
 
     void filterUpdated(QGraphicsItem* item, const cv::Mat& update);
+
+public Q_SLOTS:
+
+    void onTopicChanged(const QString& topic)
+    {
+        baseImageTopic = topic.toStdString();
+    }
 
 };    // class FilterWatchdog
 
@@ -220,6 +238,11 @@ public:
     FilterWatchdog* getFilterWatchDog(void) const
     {
         return filterWatchdog;
+    }
+
+    const std::string& imageTopic(void) const
+    {
+        return filterWatchdog->imageTopic();
     }
 
     QGraphicsItem* getGraphicsItem(void) const

--- a/insitu/scripts/new_insitu_filter
+++ b/insitu/scripts/new_insitu_filter
@@ -26,7 +26,7 @@ def makeHeaders(path):
         }}
 
     private:
-        void onInit(void);
+        void filterInit(void);
 
         void onDelete(void);
 
@@ -88,11 +88,12 @@ def makeSources(path):
         // TODO instantiation code
     }}
 
-    void {1}::onInit(void)
+    void {1}::filterInit(void)
     {{
         settingsDialog = new {1}Dialog(this);
+        size = QSize(300, 300);
 
-        // TODO initialization code
+        // TODO ROS initialization code
     }}
 
     void {1}::onDelete(void)
@@ -107,8 +108,8 @@ def makeSources(path):
             Create a transparent image to construct your overlay on
         */
         cv::Mat ret = cv::Mat(
-            settings.get("height", 300).asInt(),
-            settings.get("width", 300).asInt(),
+            height(),
+            width(),
             CV_8UC4,
             cv::Scalar(255, 255, 255, 0)
         );
@@ -371,3 +372,4 @@ makePackage(folderlist[0] + "/package.xml")
 
 os.system("tree " + pkg_name)
 print("\nDone\n")
+

--- a/insitu/src/add_filter_dialog.cpp
+++ b/insitu/src/add_filter_dialog.cpp
@@ -69,8 +69,10 @@ void AddFilterDialog::AddFilter()
             auto filter = filterLoader->loadFilter(
                 fi->getFilterName(), nameEdit->text().toStdString(), activeView->getViewTopic());
             activeView->addFilter(filter);
-            activeView =
-                nullptr;    // reset so we don't segfault on a deleted view
+
+            // reset so we don't segfault on a deleted view
+            activeView = nullptr;
+            
             accept();
         }
         catch (std::runtime_error e)

--- a/insitu/src/add_filter_dialog.cpp
+++ b/insitu/src/add_filter_dialog.cpp
@@ -67,7 +67,7 @@ void AddFilterDialog::AddFilter()
         try
         {
             auto filter = filterLoader->loadFilter(
-                fi->getFilterName(), nameEdit->text().toStdString());
+                fi->getFilterName(), nameEdit->text().toStdString(), activeView->getViewTopic());
             activeView->addFilter(filter);
             activeView =
                 nullptr;    // reset so we don't segfault on a deleted view

--- a/insitu/src/filter_factory.cpp
+++ b/insitu/src/filter_factory.cpp
@@ -30,10 +30,10 @@ std::vector<std::string> FilterFactory::getFilterList(void)
 }
 
 boost::shared_ptr<insitu::Filter>
-FilterFactory::loadFilter(const std::string& filter, const std::string& name)
+FilterFactory::loadFilter(const std::string& filter, const std::string& name, const std::string& topic)
 {
     nodelet::M_string rmap_;
-    nodelet::V_string argv_;
+    nodelet::V_string argv_ = {topic};
 
     instance_.reset();
 

--- a/insitu/src/filter_graphics_item.cpp
+++ b/insitu/src/filter_graphics_item.cpp
@@ -17,8 +17,6 @@ FilterGraphicsItem::FilterGraphicsItem(boost::shared_ptr<insitu::Filter> filter,
         setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
     }
 
-    isResizable = true;
-    isResizing = false;
     img = QImage(1, 1, QImage::Format_RGBA8888);
     
     // some jank shit, don't touch
@@ -63,11 +61,6 @@ void FilterGraphicsItem::queuedUpdate(void)
     update(boundingRect());
 }
 
-void FilterGraphicsItem::setResizable(bool resizable)
-{
-    isResizable = resizable;
-}
-
 /*
     Protected
 */
@@ -75,77 +68,6 @@ void FilterGraphicsItem::setResizable(bool resizable)
 QRectF FilterGraphicsItem::boundingRect(void) const
 {
     return img.rect();
-}
-
-void FilterGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent* event)
-{
-    if (event->button() == Qt::LeftButton)
-    {
-        if (event->modifiers() == Qt::ShiftModifier)
-        {
-            // add the item to the selection
-            setSelected(true);
-        }
-        else if (event->modifiers() == Qt::AltModifier)
-        {
-            // resize the item
-            QPointF center = itemCenter();
-            QPointF pos = event->scenePos();
-
-            double distx = abs(center.x() - pos.x());
-            double disty = abs(center.y() - pos.y());
-            if (distx > 0.4 * boundingRect().width() ||
-                disty > 0.4 * boundingRect().height())
-            {
-                initDist = sqrt(pow(distx, 2) + pow(disty, 2));
-                initScale = scale();
-                isResizing = true;
-            }
-            else
-            {
-                isResizing = false;
-            }
-        }
-        else
-        {
-            QGraphicsItem::mousePressEvent(event);
-            event->accept();
-        }
-    }
-    else if (event->button() == Qt::RightButton)
-    {
-        event->ignore();
-    }
-}
-
-void FilterGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
-{
-    if (event->modifiers() == Qt::AltModifier && isResizing && isResizable)
-    {
-        QPointF center = itemCenter();
-        QPointF pos = event->scenePos();
-        double dist = sqrt(pow((center.x() - pos.x()), 2) +
-                           pow((center.y() - pos.y()), 2));
-        setTransformOriginPoint(center);
-        setScale(initScale * dist / initDist);
-    }
-    else if (event->modifiers() != Qt::AltModifier)
-    {
-        QGraphicsItem::mouseMoveEvent(event);
-    }
-}
-
-void FilterGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
-{
-    if (event->modifiers() == Qt::AltModifier && isResizing)
-    {
-        isResizing = false;
-    }
-    else if (event->modifiers() != Qt::ShiftModifier)
-    {
-        QGraphicsItem::mouseReleaseEvent(event);
-        emit moved(pos());
-    }
 }
 
 void FilterGraphicsItem::paint(QPainter* painter,

--- a/insitu/src/filter_graphics_view.cpp
+++ b/insitu/src/filter_graphics_view.cpp
@@ -22,7 +22,6 @@ void FilterGraphicsView::setRootItem(FilterGraphicsItem* item)
     root->setFlag(QGraphicsItem::ItemIsMovable, false);
     root->setFlag(QGraphicsItem::ItemIsSelectable, false);
     root->setFlag(QGraphicsItem::ItemSendsGeometryChanges, false);
-    root->setResizable(false);
 
     connect(root, SIGNAL(imgSizeChanged(QSize)), this,
             SLOT(rootImgSizeChanged(QSize)));

--- a/insitu/src/filtered_view.cpp
+++ b/insitu/src/filtered_view.cpp
@@ -1,4 +1,5 @@
 #include "filtered_view.hpp"
+#include <string>
 #include "add_filter_dialog.hpp"
 #include "filter_card.hpp"
 #include "filter_graphics_item.hpp"
@@ -223,6 +224,11 @@ void FilteredView::updateFilter(QGraphicsItem* item, const cv::Mat& update)
 /*
     Public Functions
 */
+std::string FilteredView::getViewTopic(void) const
+{
+    return sub.getTopic();
+}
+
 void FilteredView::addFilter(boost::shared_ptr<insitu::Filter> filter)
 {
     std::string name = filter->name();
@@ -299,7 +305,7 @@ void FilteredView::restore(const Json::Value &json)
             errMsg->showMessage(QString::fromStdString("Filter must have type, skipping " + std::to_string(i) + " of " + std::to_string(json["filters"].size())));
             continue;
         }
-        auto filter = filterFactory->loadFilter(filterjson.get("type", "").asString(), filterjson.get("name", "").asString());
+        auto filter = filterFactory->loadFilter(filterjson.get("type", "").asString(), filterjson.get("name", "").asString(), sub.getTopic());
         addFilter(filter);
         if (filterjson.isMember("properties") && !filterjson["properties"].isNull()) {
             FilterGraphicsItem * fgitem = (FilterGraphicsItem*) filter->getGraphicsItem();

--- a/insitu_plugins/inc/Crosshair/Crosshair.hpp
+++ b/insitu_plugins/inc/Crosshair/Crosshair.hpp
@@ -19,7 +19,7 @@ public:
     }
 
 private:
-    void onInit(void);
+    void filterInit(void);
 
     void onDelete(void);
 

--- a/insitu_plugins/inc/Label/Label.hpp
+++ b/insitu_plugins/inc/Label/Label.hpp
@@ -19,7 +19,7 @@ public:
     }
 
 private:
-    void onInit(void);
+    void filterInit(void);
 
     void onDelete(void);
 

--- a/insitu_plugins/inc/Transparent/Transparent.hpp
+++ b/insitu_plugins/inc/Transparent/Transparent.hpp
@@ -19,7 +19,7 @@ public:
     }
 
 private:
-    void onInit(void);
+    void filterInit(void);
 
     void onDelete(void);
 

--- a/insitu_plugins/src/Crosshair/Crosshair.cpp
+++ b/insitu_plugins/src/Crosshair/Crosshair.cpp
@@ -15,7 +15,7 @@ void Crosshair::onInit(void)
 {
     settingsDialog = new CrosshairDialog(this);
 
-    // TODO initialization code
+    setSize(QSize(300,300));
 }
 
 void Crosshair::onDelete(void)
@@ -25,9 +25,7 @@ void Crosshair::onDelete(void)
 
 const cv::Mat Crosshair::apply(void)
 {
-    cv::Mat ret = cv::Mat(settings.get("width", 300).asInt(),
-                          settings.get("height", 300).asInt(), CV_8UC4,
-                          cv::Scalar(0, 0, 0, 0));
+    cv::Mat ret = cv::Mat(width(), height(), CV_8UC4, cv::Scalar(0, 0, 0, 0));
     color = (color + 1) % 256;
 
     cv::Scalar cvColor(color, color, color, 255);

--- a/insitu_plugins/src/Crosshair/Crosshair.cpp
+++ b/insitu_plugins/src/Crosshair/Crosshair.cpp
@@ -11,7 +11,7 @@ Crosshair::Crosshair(void)
     // TODO instantiation code
 }
 
-void Crosshair::onInit(void)
+void Crosshair::filterInit(void)
 {
     settingsDialog = new CrosshairDialog(this);
 

--- a/insitu_plugins/src/Label/Label.cpp
+++ b/insitu_plugins/src/Label/Label.cpp
@@ -11,14 +11,14 @@ Label::Label(void)
     // TODO instantiation code
 }
 
-void Label::onInit(void)
+void Label::filterInit(void)
 {
     settingsDialog = new LabelDialog(this);
     setSize(QSize(300, 100));
 
     // TODO initialization code
     
-    imageTopic();
+    qDebug(imageTopic().c_str());
 }
 
 void Label::onDelete(void)

--- a/insitu_plugins/src/Label/Label.cpp
+++ b/insitu_plugins/src/Label/Label.cpp
@@ -17,6 +17,8 @@ void Label::onInit(void)
     setSize(QSize(300, 100));
 
     // TODO initialization code
+    
+    imageTopic();
 }
 
 void Label::onDelete(void)
@@ -53,7 +55,7 @@ const cv::Mat Label::apply(void)
                           cv::Scalar(255, 255, 255, 0));
 
     drawtorect(ret, cv::Rect(0, 0, ret.cols, ret.rows),
-               settings.get("text", "default").asString());
+               imageTopic());
 
     return ret;
 }

--- a/insitu_plugins/src/Transparent/Transparent.cpp
+++ b/insitu_plugins/src/Transparent/Transparent.cpp
@@ -15,7 +15,7 @@ void Transparent::onInit(void)
 {
     settingsDialog = new TransparentDialog(this);
 
-    // TODO initialization code
+    setSize(QSize(300, 300));
 }
 
 void Transparent::onDelete(void)
@@ -29,8 +29,7 @@ const cv::Mat Transparent::apply(void)
         Create a transparent image to construct your overlay on
     */
     double alpha = settings.get("alpha", 0.5).asDouble();
-    cv::Mat ret = cv::Mat(settings.get("height", 300).asInt(),
-                          settings.get("width", 300).asInt(), CV_8UC4,
+    cv::Mat ret = cv::Mat(height(), width(), CV_8UC4,
                           cv::Scalar(settings.get("red", 255).asInt(),
                                      settings.get("green", 255).asInt(),
                                      settings.get("blue", 255).asInt(),

--- a/insitu_plugins/src/Transparent/Transparent.cpp
+++ b/insitu_plugins/src/Transparent/Transparent.cpp
@@ -11,7 +11,7 @@ Transparent::Transparent(void)
     // TODO instantiation code
 }
 
-void Transparent::onInit(void)
+void Transparent::filterInit(void)
 {
     settingsDialog = new TransparentDialog(this);
 


### PR DESCRIPTION
This update introduces a (small) breaking change into the `insitu` main branch. *What filter implementors need to do:* the `onInit` function in all existing filters need to be renamed to `filterInit` in both the header and source files. This does two things:

1. reduces the amount of `insitu` machinery exposed to filter implementors (`onInit` gets called by the filter loader automatically and now calls `filterInit` after running some `insitu` setup code)
2. provides an avenue for future *filter initialization time* features to be added without introducing new breaking changes. For now, it is simply passing the base image topic name from the view to the filter (and probably restored settings when loading from file in a future addition).
