### PR TITLE
Allow outside access to selected topic string and img dimensions

### DIFF
--- a/insitu/inc/filtered_view.hpp
+++ b/insitu/inc/filtered_view.hpp
@@ -122,6 +122,11 @@ public:
 
     void restore(const Json::Value& json);
 
+    // Access selected topic and image dimensions outside insitu core
+    static std::string topic_ref_;
+
+    static std::vector<int> img_dim_;
+
 private:
     void callbackImg(const sensor_msgs::Image::ConstPtr& msg);
 

--- a/insitu/src/filtered_view.cpp
+++ b/insitu/src/filtered_view.cpp
@@ -37,7 +37,7 @@ FilteredView::FilteredView(const ros::NodeHandle& parent_, QString _name,
 
     // graphics view for rendering filters
     filterScene = new QGraphicsScene(this);
-    filterScene->setBackgroundBrush(QBrush(Qt::lightGray));
+    filterScene->setBackgroundBrush(QBrush(Qt::black));
     filterView = new FilterGraphicsView(filterScene, this);
     rosImg = new FilterGraphicsItem();
     filterScene->addItem(rosImg);
@@ -149,6 +149,9 @@ void FilteredView::openFilterDialog(void)
     afd->open();
 }
 
+// Initialize static variable to access class member outside function
+std::string FilteredView::topic_ref_ = "";
+
 void FilteredView::onTopicChange(QString topic_transport)
 {
     QList<QString> l = topic_transport.split(" ");
@@ -169,6 +172,8 @@ void FilteredView::onTopicChange(QString topic_transport)
     {
         // TODO error message
     }
+    
+    topic_ref_ = topic;
 }
 
 void FilteredView::rmFilter(void)
@@ -327,6 +332,9 @@ void FilteredView::restore(const Json::Value &json)
 /*
     Private Functions
 */
+// Initialize static variable to access class member outside function
+std::vector<int> FilteredView::img_dim_{ 0, 0 };
+
 void FilteredView::callbackImg(const sensor_msgs::Image::ConstPtr& msg)
 {
     // track frames per second
@@ -368,6 +376,9 @@ void FilteredView::callbackImg(const sensor_msgs::Image::ConstPtr& msg)
                               static_cast<size_t>(filteredImg.bytesPerLine()));
         pub.publish(repub.toImageMsg());
     }
+
+    std::vector<int> filter_dim{ (cv_ptr->image).cols, (cv_ptr->image).rows };
+    img_dim_ = filter_dim;
 }
 
 void FilteredView::unloadFilter(QListWidgetItem* filterItem)


### PR DESCRIPTION
3 changes/additions to filtered_view.cpp:

1. Changed the background brush from light gray to black; black works best with image streams. 
2. Added a static string variable to provide access to the selected topic in the filters. 
3. Added a static vector to get the selected topic dimensions. This will be used to scale the filters so they look the same when put on images of different dimensions. 

For #1 I will understand if this is not approved, we can at least provide options to configure the background to suit user needs. 
For #2 and #3, going this route was the easiest way I went about it at the time. I understand if this isn't approved and there's a better way. If so, please provide a way to do this. 